### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,11 @@ matrix:
     - php: 7.4
     - php: nightly
   allow_failures:
-    - php: 7.4
     - php: nightly
 
 before_script:
   - composer self-update
-  - travis_retry composer install --prefer-source --no-interaction
+  - travis_retry composer install --prefer-dist --no-interaction
 script:
   - vendor/bin/phpunit --coverage-clover=coverage.xml
 after_success:

--- a/tests/FormatterTest.php
+++ b/tests/FormatterTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 class FormatterTest extends TestCase {
   public function testClassInit(): void {
     $this->expectException(\Error::class);
-    $formatter = new Formatter();
+    new Formatter();
   }
 
   public function testSecondFormatter(): void {


### PR DESCRIPTION
# Changed log
- The `php-7.4` version should be successful on Travis CI build.
- Using the `--prefer-dist` to install stable dependencies during `composer install` command executing.
- Removing `$formatter` variable because it's unused.